### PR TITLE
Pcc 30 define yaml config structure

### DIFF
--- a/config/basic_config.json
+++ b/config/basic_config.json
@@ -1,0 +1,25 @@
+{
+    "programs": {
+        "web_server": {
+            "command": "/usr/bin/python3 -m http.server",
+            "instances": 1,
+            "auto_start": true,
+            "auto_restart": "unexpected",
+            "start_time": 1,
+            "stop_time": 5,
+            "restart_attempts": 3,
+            "stop_signal": "SIGTERM",
+            "expected_exit_codes": [0],
+            "working_directory": "/tmp/",
+            "umask": "None",
+            "stdout_log": "top_output.log",
+            "stderr_log": "top_error.log",
+            "environment_variables": [
+                "STARTED_BY=TASKMASTER",
+                "MONITORING=true"
+            ]
+        }
+    },
+    "logging_enabled": true,
+    "log_file": "taskmaster.log"
+}

--- a/config/basic_config.json
+++ b/config/basic_config.json
@@ -1,7 +1,7 @@
 {
     "programs": {
         "web_server": {
-            "command": "/usr/bin/python3 -m http.server",
+            "command": "/usr/bin/python3 http_server.py",
             "instances": 1,
             "auto_start": true,
             "auto_restart": "unexpected",
@@ -10,13 +10,13 @@
             "restart_attempts": 3,
             "stop_signal": "SIGTERM",
             "expected_exit_codes": [0],
-            "working_directory": "/tmp/",
+            "working_directory": "../script/",
             "umask": "None",
             "stdout_log": "top_output.log",
             "stderr_log": "top_error.log",
             "environment_variables": [
-                "STARTED_BY=TASKMASTER",
-                "MONITORING=true"
+                "GREETING=Hello evaluator, good luck!",
+                "AUTHORS=Clem and Mathia"
             ]
         }
     },

--- a/script/http_server.py
+++ b/script/http_server.py
@@ -1,0 +1,19 @@
+import os
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+
+class CustomHandler(SimpleHTTPRequestHandler):
+    def do_GET(self):
+        greeting = os.getenv('GREETING', 'Hello, World!')
+        authors = os.getenv('AUTHORS', 'unknown authors')
+        message = f"{greeting}<br>This Taskmaster has been created by {authors}"
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(message.encode("utf-8"))
+
+if __name__ == "__main__":
+    port = 8000
+    server_address = ('', port)
+    httpd = HTTPServer(server_address, CustomHandler)
+    print(f"Starting server on port {port}...")
+    httpd.serve_forever()


### PR DESCRIPTION
@Cpaluszek 
- j'ai créé un script python qui launch le server sur le port 8000 avec un messaage de welcome pour le correcteur. 
- le script sera lancé quand on arrivera à parser le fichier de config au lancement de tasskmaster, => j'ai set le workdir avec le path relative qui ammene au script py meme si un path absolue serait mieux mais comme on sera sur une vm en correction on peut pas faire differemment)
- pour le moment on peut exporter à la main les var set recuperé par le script python pour le tester 
- si on ne configure pas l'env dans le fichier de config il prend de var par default